### PR TITLE
Change default formatter locale to US locale in OSMDatastore

### DIFF
--- a/src/main/java/io/opentraffic/engine/osm/OSMDataStore.java
+++ b/src/main/java/io/opentraffic/engine/osm/OSMDataStore.java
@@ -259,8 +259,9 @@ public class OSMDataStore {
 
 			if (!vexUrl.endsWith("/"))
 				vexUrl += "/";
-
-			vexUrl += String.format("%.6f,%.6f,%.6f,%.6f.pbf", south, west, north, east);
+			StringBuilder sb = new StringBuilder();
+			Formatter formatter = new Formatter(sb, Locale.US);
+			vexUrl += formatter.format("%.6f,%.6f,%.6f,%.6f.pbf", south, west, north, east);
 
 			HttpURLConnection conn;
 


### PR DESCRIPTION
With locale = Locale.FR float format is 10,10 so the URL is not well
formed for VEX.
